### PR TITLE
Clean traces folder on run

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 echo "Simulating ns3 on file: $1"
 
+rm -rf traces/
+mkdir traces
 cp user_src/* scratch/
 
 export NS_LOG=FRRQueue=level_all
 
-./ns3 build 
-./ns3 run "scratch/$1" > traces/output.log 2>&1
-
+./ns3 build
+./ns3 run "scratch/$1" >traces/output.log 2>&1


### PR DESCRIPTION
Stops the traces folder getting cluttered with traces from different topologies. May I also suggest we give all nodes labels as some shell commands don't play nicely with things prefixed "-0-....." for example. So rather opt for "-Router0-...".